### PR TITLE
セレクトボックスのデフォルトチェックを追加

### DIFF
--- a/app/controllers/weather_forecasts_controller.rb
+++ b/app/controllers/weather_forecasts_controller.rb
@@ -1,6 +1,7 @@
 class WeatherForecastsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_user!
+  before_action :set_my_city_ids, only: [:edit, :update]
 
   def index
   end
@@ -13,10 +14,16 @@ class WeatherForecastsController < ApplicationController
       flash.now[:notice] = '地域を選択してください'
       render action: :edit
     else
-      city_ids = params[:user][:city_users]
-      CityUser.update_setting_cities(@user.id, city_ids)
+      selected_city_ids = params[:user][:city_users].map(&:to_i)
+      CityUser.update_my_cities(@user.id, selected_city_ids, @my_city_ids)
       redirect_to weather_forecasts_path, notice: "地域設定を更新しました。"
     end
+  end
+
+  private
+
+  def set_my_city_ids
+    @my_city_ids = CityUser.where(user_id: @user.id).pluck(:city_id)
   end
 
 end

--- a/app/models/city.rb
+++ b/app/models/city.rb
@@ -4,6 +4,6 @@ class City < ApplicationRecord
   has_many :user, through: :city_user
 
   def self.all_id_and_name
-    City.select('id', 'name').all
+    City.select('id', 'name').includes(:city_user).all
   end
 end

--- a/app/models/city_user.rb
+++ b/app/models/city_user.rb
@@ -2,11 +2,11 @@ class CityUser < ApplicationRecord
   belongs_to :user
   belongs_to :city
 
-  def self.update_setting_cities(user_id, city_ids)
-    city_ids.each do |city_id|
-      self.create!(user_id: user_id, city_id: city_id) unless CityUser.exists?(user_id: user_id, city_id: city_id)
+  def self.update_my_cities(user_id, selected_city_ids, my_city_ids)
+    selected_city_ids.each do |selected_city_id|
+      self.create!(user_id: user_id, city_id: selected_city_id) unless my_city_ids.include?(selected_city_id)
     end
-    self.where.not(user_id: user_id, city_id: city_ids).delete_all
+    self.where.not(user_id: user_id, city_id: selected_city_ids).delete_all
   end
 
   def self.my_city_ids(user_id)

--- a/app/models/weather_forecast.rb
+++ b/app/models/weather_forecast.rb
@@ -12,7 +12,7 @@ class WeatherForecast < ApplicationRecord
   }
 
   def self.my_weather_forecasts(city_ids)
-    self.where(city_id: city_ids).all.city_id_asc.recent_target_date
+    self.where(city_id: city_ids).city_id_asc.recent_target_date.eager_load(:city).all
   end
 
   def ditsplay_weather_image

--- a/app/views/weather_forecasts/edit.html.erb
+++ b/app/views/weather_forecasts/edit.html.erb
@@ -5,7 +5,7 @@
   <div class = 'field'>
     <%= f.label :city, '地域' %><br />
     <%= f.collection_check_boxes :city_users, City.all_id_and_name, :id, :name, include_hidden: false do |city| %>
-      <%= city.check_box %>
+      <%= city.check_box checked: @my_city_ids.include?(city.value) %>
       <%= city.text %>
     <% end %>
   </div>


### PR DESCRIPTION
### eager_load → LEFT JOIN でキャッシュする。

イメージ：`SELECT * FROM users LEFT JOIN posts ON users.id = posts.user_id;`
使用例：has_one , belongs_to のとき → eager_load を使う。
理由：1対1あるいはN対1関連なのでSQLを分割して取得するより、left joinでまとめて取得。

### preload → 別クエリで IN 句を使用してキャッシュする。

イメージ：`SELECT * FROM users;` `SELECT * FROM posts WHERE posts.user_id IN (1, 2, 3, 4, 5...);`
使用例：has_many のとき → preload を使う。
理由：eager_load するとスロークエリを踏みやすいため。